### PR TITLE
Add GetAccountsSummary API to SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-flinks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Flinks API wrapper for Node.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,13 @@ import {
   GetAccountsDetailAsyncResponse
 } from './commands/accounts';
 
+import {
+  getAccountsSummary,
+  GetAccountsSummaryOptions,
+  GetAccountsSummaryResponse,
+  GetAccountsSummaryAsyncResponse
+} from './commands/accounts-summary';
+
 class FlinksClient {
   private client: Got;
 
@@ -25,6 +32,12 @@ class FlinksClient {
     options: GetAccountsDetailOptions
   ): Promise<GetAccountsDetailResponse | GetAccountsDetailAsyncResponse> {
     return getAccountsDetail(this.client, options);
+  }
+
+  public getAccountsSummary(
+    options: GetAccountsSummaryOptions
+  ): Promise<GetAccountsSummaryResponse | GetAccountsSummaryAsyncResponse> {
+    return getAccountsSummary(this.client, options);
   }
 }
 

--- a/src/commands/accounts-summary.ts
+++ b/src/commands/accounts-summary.ts
@@ -1,0 +1,108 @@
+import createDebug from 'debug';
+import { Got } from 'got';
+
+import {
+  FlinksResponseBase,
+  FlinksSummaryAccountResponse,
+  FlinksLoginResponse,
+  ResponseBase,
+  AccountResponse,
+  LoginResponse
+} from '../types';
+import { transformOptions, transformResponse } from '../lib/transform-keys';
+
+interface FlinksGetAccountsSummaryOptions {
+  requestId: string;
+  WithBalance?: boolean;
+}
+
+export interface GetAccountsSummaryOptions {
+  requestId: string;
+  withBalance?: boolean;
+}
+
+export interface FlinksGetAccountsSummaryResponse extends FlinksResponseBase {
+  Accounts: FlinksSummaryAccountResponse[];
+  Login: FlinksLoginResponse;
+  Institution: string;
+  RequestId: string;
+}
+
+export interface FlinksGetAccountsSummaryAsyncResponse extends FlinksResponseBase {
+  FlinksCode: string;
+  Message: string;
+  RequestId: string;
+}
+
+export interface GetAccountsSummaryResponse extends ResponseBase {
+  accounts: AccountResponse[];
+  login: LoginResponse;
+  institution: string;
+  requestId: string;
+}
+
+export interface GetAccountsSummaryAsyncResponse extends ResponseBase {
+  flinksCode: string;
+  message: string;
+  requestId: string;
+}
+
+const debug = createDebug('node-flinks:commands:accounts');
+
+const defaultOptions = {
+  mostRecentCached: true
+};
+
+const isResponse = (
+  data: FlinksGetAccountsSummaryResponse | FlinksGetAccountsSummaryAsyncResponse
+): data is FlinksGetAccountsSummaryResponse => {
+  return data.HttpStatusCode === 200;
+};
+
+const isAsyncResponse = (
+  data: FlinksGetAccountsSummaryResponse | FlinksGetAccountsSummaryAsyncResponse
+): data is FlinksGetAccountsSummaryResponse => {
+  return data.HttpStatusCode === 202;
+};
+
+const getAccountsSummary = async (
+  client: Got,
+  options: GetAccountsSummaryOptions
+): Promise<GetAccountsSummaryResponse | GetAccountsSummaryAsyncResponse> => {
+  const requestOptions = transformOptions<GetAccountsSummaryOptions, FlinksGetAccountsSummaryOptions>({
+    ...defaultOptions,
+    ...options
+  });
+
+  debug('request options', requestOptions);
+
+  try {
+    const response = await client.post<FlinksGetAccountsSummaryResponse | FlinksGetAccountsSummaryAsyncResponse>(
+      `BankingServices/GetAccountsSummary`,
+      {
+        json: {
+          ...requestOptions
+        },
+        responseType: 'json'
+      }
+    );
+
+    debug('flinks getAccountsSummary response', response.body);
+
+    const data = response.body;
+
+    if (isResponse(data)) {
+      return transformResponse<FlinksGetAccountsSummaryResponse, GetAccountsSummaryResponse>(data);
+    } else if (isAsyncResponse(data)) {
+      return transformResponse<FlinksGetAccountsSummaryAsyncResponse, GetAccountsSummaryAsyncResponse>(data);
+    } else {
+      throw new Error(`Unexpected response code from getAccountsSummary: ${data.HttpStatusCode}`);
+    }
+  } catch (error) {
+    debug('flinks getAccountsSummary error', error);
+
+    throw error;
+  }
+};
+
+export { getAccountsSummary };

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,21 @@ export interface FlinksAccountResponse {
   Id: string;
 }
 
+export interface FlinksSummaryAccountResponse {
+  TransitNumber: string;
+  InstitutionNumber: string;
+  OverdraftLimit: number;
+  Title: string;
+  AccountNumber: string;
+  Balance: FlinksBalanceResponse;
+  Category: string;
+  Type: string;
+  Currency: string;
+  Holder: FlinksHolderResponse;
+  EftEligibleRatio: number;
+  Id: string;
+}
+
 export interface ResponseBase {
   httpStatusCode: number;
   links: FlinksResponseLink[];

--- a/test/lib/accounts-summary.test.ts
+++ b/test/lib/accounts-summary.test.ts
@@ -1,0 +1,57 @@
+import { isMessageValid } from '../../src/lib/authenticity';
+
+const flinksResponse = {
+  ResponseType: 'GetAccountsSummary',
+  HttpStatusCode: 200,
+  Accounts: [
+    {
+      TransitNumber: '77777',
+      InstitutionNumber: '777',
+      OverdraftLimit: 0,
+      Title: 'Chequing CAD',
+      AccountNumber: '1111000',
+      Category: 'Operations',
+      Type: 'Chequing',
+      Currency: 'CAD',
+      Id: 'ae1dac72-70da-4626-fed8-08d682e1ff4a',
+      Holder: 'John Flinkyfoot',
+      Balance: {
+        Available: 6.04,
+        Current: 49993.96,
+        Limit: 5000
+      }
+    }
+  ],
+  Login: {
+    Username: 'Greatday',
+    IsScheduledRefresh: false,
+    LastRefresh: '2019-05-09T13:47:46.5227901',
+    Type: 'Personal',
+    Id: '5e115eac-1209-4f19-641c-08d6d484e2fe'
+  },
+  Institution: 'FlinksCapital',
+  RequestId: '1243c283-e0ca-4fda-a5e4-343068430190'
+};
+
+describe('isMessageValid', () => {
+  test('valid message is valid', () => {
+    const message = JSON.stringify(flinksResponse);
+    const signature = 'ojahxTBoMUfLsZyAoT67qXix1H0faUKXFTmu6V7vHeE=';
+
+    expect(isMessageValid(message, signature, 'secret')).toBe(true);
+  });
+
+  test('bad signature is invalid', () => {
+    const message = JSON.stringify(flinksResponse);
+    const signature = 'badsignature';
+
+    expect(isMessageValid(message, signature, 'secret')).toBe(false);
+  });
+
+  test('bad message is invalid', () => {
+    const message = JSON.stringify(flinksResponse).replace('a', 'e');
+    const signature = 'Lc+We2IOaDnEwxzynulc1M8VOuyXpVe+H8ep0iuqWhk=';
+
+    expect(isMessageValid(message, signature, 'secret')).toBe(false);
+  });
+});


### PR DESCRIPTION
Add GetAccountsSummary API to SDK

This is slightly different than GetAccountsDetails

It does not include transactions but includes EFT Eligibility

https://docs.flinks.io/reference/accounts-information#getaccountssummary