### PR TITLE
expose FlinksErrorResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Node Flinks Changelog
 
+## 0.5.1 (November 4, 2022)
+
+- Expose `FlinksErrorFlinksErrorResponse`
+
 ## 0.5.0 (August 22, 2022)
 
 - Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.1 (November 4, 2022)
 
-- Expose `FlinksErrorFlinksErrorResponse`
+- Expose `FlinksErrorResponse`
 
 ## 0.5.0 (August 22, 2022)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-flinks",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Flinks API wrapper for Node.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,16 @@
 import FlinksClient from './client';
 
-export { AuthorizeOptions, FlinksAuthorizeResponse, AuthorizeResponse } from './commands/authorize';
-
 export {
-  GetAccountsDetailOptions,
-  GetAccountsDetailAsyncOptions,
-  FlinksGetAccountsDetailResponse,
-  FlinksGetAccountsDetailAsyncResponse,
-  GetAccountsDetailResponse,
-  GetAccountsDetailAsyncResponse,
+  FlinksGetAccountsDetailAsyncResponse, FlinksGetAccountsDetailResponse, GetAccountsDetailAsyncOptions, GetAccountsDetailAsyncResponse, GetAccountsDetailOptions, GetAccountsDetailResponse
 } from './commands/accounts-detail';
-
 export {
-  GetAccountsSummaryOptions,
-  GetAccountsSummaryAsyncOptions,
-  FlinksGetAccountsSummaryResponse,
-  FlinksGetAccountsSummaryAsyncResponse,
-  GetAccountsSummaryResponse,
-  GetAccountsSummaryAsyncResponse,
+  FlinksGetAccountsSummaryAsyncResponse, FlinksGetAccountsSummaryResponse, GetAccountsSummaryAsyncOptions, GetAccountsSummaryAsyncResponse, GetAccountsSummaryOptions, GetAccountsSummaryResponse
 } from './commands/accounts-summary';
-
+export { AuthorizeOptions, AuthorizeResponse, FlinksAuthorizeResponse } from './commands/authorize';
 export {
-  GetStatementsOptions,
-  GetStatementsAsyncOptions,
-  FlinksGetStatementsResponse,
-  FlinksGetStatementsAsyncResponse,
-  GetStatementsResponse,
-  GetStatementsAsyncResponse,
+  FlinksGetStatementsAsyncResponse, FlinksGetStatementsResponse, GetStatementsAsyncOptions, GetStatementsAsyncResponse, GetStatementsOptions, GetStatementsResponse
 } from './commands/statements';
-
 export * from './lib/authenticity';
+export { FlinksErrorResponse } from './lib/flinks-error';
 
 export default FlinksClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,29 @@
 import FlinksClient from './client';
 
 export {
-  FlinksGetAccountsDetailAsyncResponse, FlinksGetAccountsDetailResponse, GetAccountsDetailAsyncOptions, GetAccountsDetailAsyncResponse, GetAccountsDetailOptions, GetAccountsDetailResponse
+  FlinksGetAccountsDetailAsyncResponse,
+  FlinksGetAccountsDetailResponse,
+  GetAccountsDetailAsyncOptions,
+  GetAccountsDetailAsyncResponse,
+  GetAccountsDetailOptions,
+  GetAccountsDetailResponse,
 } from './commands/accounts-detail';
 export {
-  FlinksGetAccountsSummaryAsyncResponse, FlinksGetAccountsSummaryResponse, GetAccountsSummaryAsyncOptions, GetAccountsSummaryAsyncResponse, GetAccountsSummaryOptions, GetAccountsSummaryResponse
+  FlinksGetAccountsSummaryAsyncResponse,
+  FlinksGetAccountsSummaryResponse,
+  GetAccountsSummaryAsyncOptions,
+  GetAccountsSummaryAsyncResponse,
+  GetAccountsSummaryOptions,
+  GetAccountsSummaryResponse,
 } from './commands/accounts-summary';
 export { AuthorizeOptions, AuthorizeResponse, FlinksAuthorizeResponse } from './commands/authorize';
 export {
-  FlinksGetStatementsAsyncResponse, FlinksGetStatementsResponse, GetStatementsAsyncOptions, GetStatementsAsyncResponse, GetStatementsOptions, GetStatementsResponse
+  FlinksGetStatementsAsyncResponse,
+  FlinksGetStatementsResponse,
+  GetStatementsAsyncOptions,
+  GetStatementsAsyncResponse,
+  GetStatementsOptions,
+  GetStatementsResponse,
 } from './commands/statements';
 export * from './lib/authenticity';
 export { FlinksErrorResponse } from './lib/flinks-error';


### PR DESCRIPTION
Expose `FlinksErrorResponse` to not have it duplicated in every service that is using the library.