### PR TITLE
fix globbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "files": [
-    "/build/*"
+    "/build/**"
   ],
   "dependencies": {
     "camelcase-keys": "^6.2.2",


### PR DESCRIPTION
Sorry somehow missed this one in my first pass.

NPM v 9 contains an update that changes their wildcard matching for files in package.json to not include sub-directories with a single asterisk wildcard eg. build/*. For that reason we want to update all of our build strings that would have been including subdirectories in NPM 8 to continue including them in NPM 9

There's a thread on this [here](https://neofinancial.slack.com/archives/C01DF3L7VQA/p1676322906174569) but we've confirmed it in the core-ledger (by accidentally publishing a bad version :'( and then trying multiple builds locally on multiple devices.)

Also opened an issue with NPM
https://github.com/npm/cli/issues/6164